### PR TITLE
Remove unused indices, create only if db doesn't already exist

### DIFF
--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -633,16 +633,20 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
-                print(co_md)
-                co_md_set_on_insert = _build_md_insert_doc(co_md)
-                co_md_update_doc = {  # update document
-                    "$setOnInsert": co_md_set_on_insert,
-                    "$set": {
-                        "last_modified": datetime.datetime.now().strftime(
-                            "%Y-%m-%dT%H:%M:%SZ"
-                        )
-                    },
-                }
+                co_md_json = json.dumps(co_md)
+                if co_md_json not in meta_json:
+                    meta_json.add(co_md_json)
+                    co_md_set_on_insert = _build_md_insert_doc(co_md)
+                    co_md_update_doc = {  # update document
+                        "$setOnInsert": co_md_set_on_insert,
+                        "$set": {
+                            "last_modified": datetime.datetime.now().strftime(
+                                "%Y-%m-%dT%H:%M:%SZ"
+                            )
+                        },
+                    }
+                else:
+                    pass
 
                 meta_docs.append(
                     UpdateOne(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -184,7 +184,7 @@ class MongoDatabase(MongoClient):
         configuration_type=AtomicConfiguration,
         nprocs=1,
         uri=None,
-        drop_database=False,
+        # drop_database=False,
         user=None,
         pwrd=None,
         port=27017,
@@ -247,8 +247,8 @@ class MongoDatabase(MongoClient):
 
         self.database_name = database_name
 
-        if drop_database:
-            self.drop_database(database_name)
+        # if drop_database:
+        #     self.drop_database(database_name)
 
         self.configurations = self[database_name][_CONFIGS_COLLECTION]
         self.property_instances = self[database_name][_PROPS_COLLECTION]
@@ -299,9 +299,9 @@ class MongoDatabase(MongoClient):
         self.configurations.create_index(
             keys="relationships.metadata", name="co_relationships.metadata"
         )
-        self.configurations.create_index(
-            keys="relationships.data_object", name="co_relationships.data_object"
-        )
+        # self.configurations.create_index(
+        #     keys="relationships.data_object", name="co_relationships.data_object"
+        # )
         self.configurations.create_index(
             keys="relationships.dataset", name="co_relationships.dataset"
         )

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -290,9 +290,9 @@ class MongoDatabase(MongoClient):
         self.data_objects.create_index(
             keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
         )
-        self.property_instances.create_index(
-            keys="relationships.metadata", name="pi_relationships.metadata"
-        )
+        # self.property_instances.create_index(
+        #     keys="relationships.metadata", name="pi_relationships.metadata"
+        # )
         self.configuration_sets.create_index(
             keys="relationships.dataset", name="cs_relationships.dataset"
         )
@@ -305,9 +305,9 @@ class MongoDatabase(MongoClient):
         self.configurations.create_index(
             keys="relationships.dataset", name="co_relationships.dataset"
         )
-        self.property_instances.create_index(
-            keys="relationships.data_object", name="pi_relationships.data_object"
-        )
+        # self.property_instances.create_index(
+        #     keys="relationships.data_object", name="pi_relationships.data_object"
+        # )
         self.property_instances.create_index(
             keys="relationships.dataset", name="pi_relationships.dataset"
         )

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -633,10 +633,11 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
-                co_md_json = json.dumps(co_md)
+
+                co_md_set_on_insert = _build_md_insert_doc(co_md)
+                co_md_json = json.dumps(co_md_set_on_insert)
                 if co_md_json not in meta_json:
                     meta_json.add(co_md_json)
-                    co_md_set_on_insert = _build_md_insert_doc(co_md)
                     co_md_update_doc = {  # update document
                         "$setOnInsert": co_md_set_on_insert,
                         "$set": {

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -731,7 +731,8 @@ class MongoDatabase(MongoClient):
 
                             metadata_hashes.append(pi_md_hash)
                         else:
-                            print("pi-md already in pi_md_json_doc")
+                            # print("pi-md already in pi_md_json_doc")
+                            pass
 
                     else:
                         prop = Property.from_definition(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -729,6 +729,8 @@ class MongoDatabase(MongoClient):
                             )
 
                             metadata_hashes.append(pi_md_hash)
+                        else:
+                            print("pi-md already in pi_md_json_doc")
 
                     else:
                         prop = Property.from_definition(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -9,7 +9,6 @@ import numpy as np
 from tqdm import tqdm
 import multiprocessing
 from copy import deepcopy
-from deepdiff import DeepDiff
 from hashlib import sha512
 from functools import partial
 from pymongo import MongoClient, UpdateOne

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -257,76 +257,79 @@ class MongoDatabase(MongoClient):
         self.configuration_sets = self[database_name][_CONFIGSETS_COLLECTION]
         self.datasets = self[database_name][_DATASETS_COLLECTION]
         self.aggregated_info = self[database_name][_AGGREGATED_INFO_COLLECTION]
+        if database_name not in self.list_database_names():
+            print(f"Database {database_name} does not yet exist. Creating indices...")
+            self.property_definitions.create_index(
+                keys="definition.property-name",
+                name="definition.property-name",
+                unique=True,
+            )
 
-        self.property_definitions.create_index(
-            keys="definition.property-name",
-            name="definition.property-name",
-            unique=True,
-        )
+            self.configuration_sets.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
+            self.datasets.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
 
-        self.configuration_sets.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
-        self.datasets.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
+            self.configurations.create_index(keys="hash", name="hash", unique=True)
+            self.property_instances.create_index(keys="hash", name="hash", unique=True)
+            self.metadata.create_index(keys="hash", name="hash", unique=True)
+            self.data_objects.create_index(keys="hash", name="hash", unique=True)
+            self.configuration_sets.create_index(keys="hash", name="hash", unique=True)
+            self.datasets.create_index(keys="hash", name="hash", unique=True)
+            self.configurations.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
+            self.property_instances.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
+            self.metadata.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
+            self.data_objects.create_index(
+                keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
+            )
+            # self.property_instances.create_index(
+            #     keys="relationships.metadata", name="pi_relationships.metadata"
+            # )
+            self.configuration_sets.create_index(
+                keys="relationships.dataset", name="cs_relationships.dataset"
+            )
+            self.configurations.create_index(
+                keys="relationships.metadata", name="co_relationships.metadata"
+            )
+            # self.configurations.create_index(
+            #     keys="relationships.data_object", name="co_relationships.data_object"
+            # )
+            self.configurations.create_index(
+                keys="relationships.dataset", name="co_relationships.dataset"
+            )
+            # self.property_instances.create_index(
+            #     keys="relationships.data_object", name="pi_relationships.data_object"
+            # )
+            self.property_instances.create_index(
+                keys="relationships.dataset", name="pi_relationships.dataset"
+            )
+            self.data_objects.create_index(
+                keys="relationships.dataset", name="do_relationships.dataset"
+            )
+            self.configurations.create_index(
+                keys="relationships.configuration_set",
+                name="co_relationships.configuration_set",
+            )
 
-        self.configurations.create_index(keys="hash", name="hash", unique=True)
-        self.property_instances.create_index(keys="hash", name="hash", unique=True)
-        self.metadata.create_index(keys="hash", name="hash", unique=True)
-        self.data_objects.create_index(keys="hash", name="hash", unique=True)
-        self.configuration_sets.create_index(keys="hash", name="hash", unique=True)
-        self.datasets.create_index(keys="hash", name="hash", unique=True)
-        self.configurations.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
-        self.property_instances.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
-        self.metadata.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
-        self.data_objects.create_index(
-            keys=SHORT_ID_STRING_NAME, name=SHORT_ID_STRING_NAME, unique=True
-        )
-        # self.property_instances.create_index(
-        #     keys="relationships.metadata", name="pi_relationships.metadata"
-        # )
-        self.configuration_sets.create_index(
-            keys="relationships.dataset", name="cs_relationships.dataset"
-        )
-        self.configurations.create_index(
-            keys="relationships.metadata", name="co_relationships.metadata"
-        )
-        # self.configurations.create_index(
-        #     keys="relationships.data_object", name="co_relationships.data_object"
-        # )
-        self.configurations.create_index(
-            keys="relationships.dataset", name="co_relationships.dataset"
-        )
-        # self.property_instances.create_index(
-        #     keys="relationships.data_object", name="pi_relationships.data_object"
-        # )
-        self.property_instances.create_index(
-            keys="relationships.dataset", name="pi_relationships.dataset"
-        )
-        self.data_objects.create_index(
-            keys="relationships.dataset", name="do_relationships.dataset"
-        )
-        self.configurations.create_index(
-            keys="relationships.configuration_set",
-            name="co_relationships.configuration_set",
-        )
-
-        self.aggregated_info.create_index(keys="type", name="type")
-        self.aggregated_info.create_index(keys="formula", name="formula`")
-        self.aggregated_info.create_index(
-            keys="relationships.dataset", name="ai_relationships.dataset"
-        )
-        self.aggregated_info.create_index(
-            keys="relationships.configuration_set",
-            name="ai_relationships.configuration_set",
-        )
+            self.aggregated_info.create_index(keys="type", name="type")
+            self.aggregated_info.create_index(keys="formula", name="formula`")
+            self.aggregated_info.create_index(
+                keys="relationships.dataset", name="ai_relationships.dataset"
+            )
+            self.aggregated_info.create_index(
+                keys="relationships.configuration_set",
+                name="ai_relationships.configuration_set",
+            )
+        else:
+            print(f"Found database {database_name}.")
 
         self.nprocs = nprocs
 
@@ -706,7 +709,6 @@ class MongoDatabase(MongoClient):
                         pi_md_set_on_insert = _build_md_insert_doc(pi_md)
                         pi_md_json = json.dumps(pi_md_set_on_insert)
                         if pi_md_json not in pi_md_json_doc:
-                            print("adding pi_md to pi_md_json_doc")
 
                             pi_md_json_doc[pi_md_json] = pi_md_hash
 

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -607,7 +607,7 @@ class MongoDatabase(MongoClient):
         # ca_ids = set()
         config_docs = []
         property_docs = []
-        calc_docs = []
+        do_docs = []
         meta_docs = []
         co_md_json_doc = dict()
         pi_md_json_doc = dict()
@@ -707,6 +707,7 @@ class MongoDatabase(MongoClient):
                         pi_md_set_on_insert = _build_md_insert_doc(pi_md)
                         pi_md_json = json.dumps(pi_md_set_on_insert)
                         if pi_md_json not in pi_md_json_doc:
+                            print("adding pi_md to pi_md_json_doc")
 
                             pi_md_json_doc[pi_md_json] = pi_md_hash
 
@@ -766,7 +767,7 @@ class MongoDatabase(MongoClient):
                         if "source-unit" in prop[k]:
                             setOnInsert[k]["source-unit"] = prop[k]["source-unit"]
                         # TODO: Look at: can probably safely move out one level
-                    pi_relationships_dict["metadata"] = "MD_" + str(pi_md._hash)
+                    pi_relationships_dict["metadata"] = "MD_" + pi_md_hash
                     pi_update_doc = {
                         "$setOnInsert": {
                             "hash": pi_hash,
@@ -814,7 +815,7 @@ class MongoDatabase(MongoClient):
                     )
                 },
             }
-            calc_docs.append(
+            do_docs.append(
                 UpdateOne(
                     {"hash": do_hash},
                     ca_update_doc,
@@ -862,8 +863,8 @@ class MongoDatabase(MongoClient):
             nmatch = res.bulk_api_result["nMatched"]
             if nmatch:
                 warnings.warn("{} duplicate properties detected".format(nmatch))
-        if calc_docs:
-            res = coll_data_objects.bulk_write(calc_docs, ordered=False)
+        if do_docs:
+            res = coll_data_objects.bulk_write(do_docs, ordered=False)
             nmatch = res.bulk_api_result["nMatched"]
             if nmatch:
                 warnings.warn("{} duplicate data objects detected".format(nmatch))

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -9,6 +9,7 @@ import numpy as np
 from tqdm import tqdm
 import multiprocessing
 from copy import deepcopy
+from deepdiff import DeepDiff
 from hashlib import sha512
 from functools import partial
 from pymongo import MongoClient, UpdateOne
@@ -608,9 +609,7 @@ class MongoDatabase(MongoClient):
         property_docs = []
         calc_docs = []
         meta_docs = []
-        #        co_relationships_dict = {}
-        #        pi_relationships_dict = {}
-        meta_update_dict = {}
+        meta_json = set()
         # Add all of the configurations into the Mongo server
         ai = 1
         for atoms in tqdm(
@@ -634,6 +633,7 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
+                print(co_md)
                 co_md_set_on_insert = _build_md_insert_doc(co_md)
                 co_md_update_doc = {  # update document
                     "$setOnInsert": co_md_set_on_insert,
@@ -1582,7 +1582,7 @@ class MongoDatabase(MongoClient):
             )
         )
         print(
-            f"Inserting configuration set",
+            "Inserting configuration set",
             f"({name}):".rjust(22),
             f"{len(filtered_cos)}".rjust(7),
         )
@@ -1666,7 +1666,8 @@ class MongoDatabase(MongoClient):
         )
 
     # TODO: need to make sure can't make duplicate CS just with different versions
-    # TODO: Could do this by creating ConfigurationSets for all versioned CS and use a defined equality with hashing
+    # TODO: Could do this by creating ConfigurationSets for all versioned CS and
+    # TODO: use a defined equality with hashing
     def update_configuration_set(self, cs_id, add_ids=None, remove_ids=None):
         if add_ids is None and remove_ids is None:
             raise RuntimeError(
@@ -1875,15 +1876,15 @@ class MongoDatabase(MongoClient):
             # 'methods_counts': [],
         }
 
-        ignore_keys = {
-            "property-id",
-            "property-title",
-            "property-description",
-            "_id",
-            SHORT_ID_STRING_NAME,
-            "property-name",
-            "hash",
-        }
+        # ignore_keys = {
+        #     "property-id",
+        #     "property-title",
+        #     "property-description",
+        #     "_id",
+        #     SHORT_ID_STRING_NAME,
+        #     "property-name",
+        #     "hash",
+        # }
 
         co_ids = []
 
@@ -2582,7 +2583,7 @@ class MongoDatabase(MongoClient):
         ds_doc = self.datasets.find_one({SHORT_ID_STRING_NAME: ds_id})
 
         configuration_sets = []
-        property_ids = []
+        # property_ids = []
 
         # Loop over configuration sets
         cursor = self.configuration_sets.find(


### PR DESCRIPTION
Issue: now-unused indices were still being created (e.g. property_instances.relationships.metadata),
and were being created every time a colabfit.tools.database.MongoDatabase was instantiated, as the create_index functions were being called directly after initialization.

If an (unused) index had been removed, the index would be recreated when the next MongoDatabase instance was created.

This change:
Removes indices that are no longer needed from property instances and configurations collections
Checks whether database has already been created; if so, does not call create_index.

