### PR TITLE
Use db.collection.aggregate() for configuration and data object configuration

### DIFF
--- a/colabfit/tools/configuration.py
+++ b/colabfit/tools/configuration.py
@@ -446,10 +446,10 @@ class AtomicConfiguration(BaseConfiguration, Atoms):
             nsites += res["nsites_total"][0]["nsites_total"]
             elements.update(res["set_elements"][0]["elements"])
             nperiodic_dimensions.update(
-                res["nperiodic_dimensions"][0]["nperiodic_dimensions"]
+                set(res["nperiodic_dimensions"][0]["nperiodic_dimensions"])
             )
             dimension_types.update(
-                tuple(res["dimension_types"][0]["dimension_types"][0])
+                set([tuple(x) for x in res["dimension_types"][0]["dimension_types"]])
             )
 
         elem_match = re.compile(r"(?P<elem>[A-Z][a-z]?)(?P<num>\d*)")

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -633,16 +633,20 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
-                print(co_md)
-                co_md_set_on_insert = _build_md_insert_doc(co_md)
-                co_md_update_doc = {  # update document
-                    "$setOnInsert": co_md_set_on_insert,
-                    "$set": {
-                        "last_modified": datetime.datetime.now().strftime(
-                            "%Y-%m-%dT%H:%M:%SZ"
-                        )
-                    },
-                }
+                co_md_json = json.dumps(co_md)
+                if co_md_json not in meta_json:
+                    meta_json.add(co_md_json)
+                    co_md_set_on_insert = _build_md_insert_doc(co_md)
+                    co_md_update_doc = {  # update document
+                        "$setOnInsert": co_md_set_on_insert,
+                        "$set": {
+                            "last_modified": datetime.datetime.now().strftime(
+                                "%Y-%m-%dT%H:%M:%SZ"
+                            )
+                        },
+                    }
+                else:
+                    pass
 
                 meta_docs.append(
                     UpdateOne(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -2055,10 +2055,12 @@ class MongoDatabase(MongoClient):
         ds_id=None,
         authors=None,
         cs_ids=None,
-        links=None,
         description="",
         data_license="CC0",
         publication_year=None,
+        data_link=None,
+        publication_link=None,
+        other_links=None,
         resync=False,
         verbose=False,
         overloaded_ds_id=None,
@@ -2082,17 +2084,24 @@ class MongoDatabase(MongoClient):
             cs_ids (list or str, default=None):
                 The IDs of the configuration sets to link to the dataset.
 
-            links (list or str or None):
-                External links (e.g., journal articles, Git repositories, ...)
-                to be associated with the dataset. If None, then no links are
-                added.
+            publication_link (str or None):
+                Source publication link (e.g., journal article DOI)
+                to be associated with the dataset.
+            
+            data_link (str or None):
+                Source data link (e.g., repository DOI, GitHub link)
+                to be associated with the dataset.
+
+            other_links (list or str or None):
+                Other links associated with dataset (e.g., GitHub link, second
+                publication DOI) to be associated with the dataset.
 
             description (str or None):
                 A human-readable description of the dataset. If None, then not
                 description is added.
 
             data_license (str):
-                License associated with the Dataset's data
+                License associated with the Dataset's data. SPDX identifier.
 
             resync (bool):
                 If True, re-synchronizes the configuration sets and properties
@@ -2150,9 +2159,15 @@ class MongoDatabase(MongoClient):
                         auth
                     )
                 )
+        if other_links is not None:
+            if isinstance(other_links, str):
+                other_links = [other_links]
+        links = {
+            "source-publication":publication_link,
+            "source-data":data_link,
+            "other":other_links
+            }
 
-        if isinstance(links, str):
-            links = [links]
 
         ds_hash = sha512()
         if cs_ids is not None:

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -1948,10 +1948,10 @@ class MongoDatabase(MongoClient):
                             {
                                 "$group": {
                                     "_id": None,
-                                    "ndata_object ": {"$sum": 1},
+                                    "ndata_object": {"$sum": 1},
                                 }
                             },
-                            {"$project": {"_id": 0, "ndata_object ": 1}},
+                            {"$project": {"_id": 0, "ndata_object": 1}},
                         ],
                         "configuration_ids": [
                             {
@@ -1971,7 +1971,7 @@ class MongoDatabase(MongoClient):
             results = self.data_objects.aggregate(pipeline)
             results = next(results)
             co_ids.extend(results["configuration_ids"][0]["configuration_ids"])
-            ndata_object += results["ndata_object "][0]["ndata_object "]
+            ndata_object += results["ndata_object"][0]["ndata_object"]
             for x in results["typesCount"]:
                 property_types[x["_id"]] += x["count"]
 
@@ -1985,7 +1985,7 @@ class MongoDatabase(MongoClient):
         )
         aggregated_info["property_types"] = list(property_types.keys())
         aggregated_info["property_types_counts"] = list(property_types.values())
-        aggregated_info["ndata_object "] = ndata_object
+        aggregated_info["ndata_object"] = ndata_object
         return aggregated_info
 
     # TODO: Make Configuration "type" agnostic (only need to change docstring)

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -633,10 +633,11 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
-                co_md_json = json.dumps(co_md)
+
+                co_md_set_on_insert = _build_md_insert_doc(co_md)
+                co_md_json = json.dumps(co_md_set_on_insert)
                 if co_md_json not in meta_json:
                     meta_json.add(co_md_json)
-                    co_md_set_on_insert = _build_md_insert_doc(co_md)
                     co_md_update_doc = {  # update document
                         "$setOnInsert": co_md_set_on_insert,
                         "$set": {

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -1557,7 +1557,7 @@ class MongoDatabase(MongoClient):
 
         # Add the backwards relationships CO->CS
         config_docs = []
-        co_hash_batch_size = 10000
+        co_hash_batch_size = 50000
         co_hash_batches = [
             hashes[i : i + co_hash_batch_size]
             for i in range(0, len(hashes), co_hash_batch_size)
@@ -1919,7 +1919,7 @@ class MongoDatabase(MongoClient):
         """
         if isinstance(do_hashes, str):
             do_hashes = [do_hashes]
-        do_hash_batch_size = 10000
+        do_hash_batch_size = 50000
         do_hash_batches = [
             do_hashes[i : i + do_hash_batch_size]
             for i in range(0, len(do_hashes), do_hash_batch_size)

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -731,7 +731,8 @@ class MongoDatabase(MongoClient):
 
                             metadata_hashes.append(pi_md_hash)
                         else:
-                            print("pi-md already in pi_md_json_doc")
+                            # print("pi-md already in pi_md_json_doc")
+                            pass
 
                     else:
                         prop = Property.from_definition(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -729,6 +729,8 @@ class MongoDatabase(MongoClient):
                             )
 
                             metadata_hashes.append(pi_md_hash)
+                        else:
+                            print("pi-md already in pi_md_json_doc")
 
                     else:
                         prop = Property.from_definition(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -649,9 +649,9 @@ class MongoDatabase(MongoClient):
                     co_md_update_doc = {  # update document
                         "$setOnInsert": co_md_set_on_insert,
                         "$set": {
-                            "last_modified": datetime.datetime.now().strftime(
-                                "%Y-%m-%dT%H:%M:%SZ"
-                            )
+                            "last_modified": datetime.datetime.now(
+                                tz=datetime.timezone.utc
+                            ).strftime("%Y-%m-%dT%H:%M:%SZ")
                         },
                     }
                     co_md_json_doc[co_md_json] = co_md_update_doc
@@ -716,9 +716,9 @@ class MongoDatabase(MongoClient):
                             pi_md_update_doc = {  # update document
                                 "$setOnInsert": pi_md_set_on_insert,
                                 "$set": {
-                                    "last_modified": datetime.datetime.now().strftime(
-                                        "%Y-%m-%dT%H:%M:%SZ"
-                                    )
+                                    "last_modified": datetime.datetime.now(
+                                        tz=datetime.timezone.utc
+                                    ).strftime("%Y-%m-%dT%H:%M:%SZ")
                                 },
                             }
 
@@ -778,9 +778,9 @@ class MongoDatabase(MongoClient):
                             pname: setOnInsert,
                         },
                         "$set": {
-                            "last_modified": datetime.datetime.now().strftime(
-                                "%Y-%m-%dT%H:%M:%SZ"
-                            )
+                            "last_modified": datetime.datetime.now(
+                                tz=datetime.timezone.utc
+                            ).strftime("%Y-%m-%dT%H:%M:%SZ")
                         },
                     }
 
@@ -812,9 +812,9 @@ class MongoDatabase(MongoClient):
                 #     'ncounts': 1
                 # },
                 "$set": {
-                    "last_modified": datetime.datetime.now().strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
-                    )
+                    "last_modified": datetime.datetime.now(
+                        tz=datetime.timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ")
                 },
             }
             do_docs.append(
@@ -1545,9 +1545,9 @@ class MongoDatabase(MongoClient):
                 },
                 "$set": {
                     "aggregated_info": aggregated_info,
-                    "last_modified": datetime.datetime.now().strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
-                    ),
+                    "last_modified": datetime.datetime.now(
+                        tz=datetime.timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 },
                 "$addToSet": {"relationships": {"dataset": ds_id}},
             },
@@ -2204,9 +2204,9 @@ class MongoDatabase(MongoClient):
                 },
                 "$set": {
                     "aggregated_info": aggregated_info,
-                    "last_modified": datetime.datetime.now().strftime(
-                        "%Y-%m-%dT%H:%M:%SZ"
-                    ),
+                    "last_modified": datetime.datetime.now(
+                        tz=datetime.timezone.utc
+                    ).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 },
             },
             upsert=True,
@@ -2879,9 +2879,9 @@ class MongoDatabase(MongoClient):
                             {
                                 "$setOnInsert": {"type": k, "formula": j},
                                 "$set": {
-                                    "last_modified": datetime.datetime.now().strftime(
-                                        "%Y-%m-%dT%H:%M:%SZ"
-                                    )
+                                    "last_modified": datetime.datetime.now(
+                                        tz=datetime.timezone.utc
+                                    ).strftime("%Y-%m-%dT%H:%M:%SZ")
                                 },
                                 "$addToSet": {
                                     "relationships": {
@@ -3645,7 +3645,9 @@ def _build_co_update_doc(configuration):
     co_update_doc = {
         "$setOnInsert": {"hash": co_hash, SHORT_ID_STRING_NAME: "CO_" + co_hash},
         "$set": {
-            "last_modified": datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ")
+            "last_modified": datetime.datetime.now(tz=datetime.timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
         },
         "$addToSet": {
             "names": {"$each": list(configuration.info[ATOMS_NAME_FIELD])},

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -1944,7 +1944,7 @@ class MongoDatabase(MongoClient):
                                 }
                             },
                         ],
-                        "ndata_object ": [
+                        "ndata_object": [
                             {
                                 "$group": {
                                     "_id": None,

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -2058,6 +2058,7 @@ class MongoDatabase(MongoClient):
         links=None,
         description="",
         data_license="CC0",
+        publication_year=None,
         resync=False,
         verbose=False,
         overloaded_ds_id=None,
@@ -2213,6 +2214,7 @@ class MongoDatabase(MongoClient):
                     "description": description,
                     "hash": str(ds_hash),
                     "license": data_license,
+                    "publication-year": publication_year,
                 },
                 "$set": {
                     "aggregated_info": aggregated_info,

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -1577,20 +1577,7 @@ class MongoDatabase(MongoClient):
                     hint="hash",
                 )
             )
-        # for co_hash in hashes:
-        # config_docs.append(
-        #     UpdateOne(
-        #         {"hash": co_hash},
-        #         {"$set": {"relationships.$[elem].configuration_set": cs_id}},
-        #         array_filters=[
-        #             {
-        #                 "elem.dataset": ds_id,
-        #                 "elem.configuration_set": {"$exists": False},
-        #             }
-        #         ],
-        #         hint="hash",
-        #     )
-        # )
+
         co_rel_time = time.time()
         if verbose:
             print(f"Inserting {len(hashes)} configuration set relationships...")

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -607,7 +607,7 @@ class MongoDatabase(MongoClient):
         # ca_ids = set()
         config_docs = []
         property_docs = []
-        calc_docs = []
+        do_docs = []
         meta_docs = []
         co_md_json_doc = dict()
         pi_md_json_doc = dict()
@@ -707,6 +707,7 @@ class MongoDatabase(MongoClient):
                         pi_md_set_on_insert = _build_md_insert_doc(pi_md)
                         pi_md_json = json.dumps(pi_md_set_on_insert)
                         if pi_md_json not in pi_md_json_doc:
+                            print("adding pi_md to pi_md_json_doc")
 
                             pi_md_json_doc[pi_md_json] = pi_md_hash
 
@@ -766,7 +767,7 @@ class MongoDatabase(MongoClient):
                         if "source-unit" in prop[k]:
                             setOnInsert[k]["source-unit"] = prop[k]["source-unit"]
                         # TODO: Look at: can probably safely move out one level
-                    pi_relationships_dict["metadata"] = "MD_" + str(pi_md._hash)
+                    pi_relationships_dict["metadata"] = "MD_" + pi_md_hash
                     pi_update_doc = {
                         "$setOnInsert": {
                             "hash": pi_hash,
@@ -814,7 +815,7 @@ class MongoDatabase(MongoClient):
                     )
                 },
             }
-            calc_docs.append(
+            do_docs.append(
                 UpdateOne(
                     {"hash": do_hash},
                     ca_update_doc,
@@ -862,8 +863,8 @@ class MongoDatabase(MongoClient):
             nmatch = res.bulk_api_result["nMatched"]
             if nmatch:
                 warnings.warn("{} duplicate properties detected".format(nmatch))
-        if calc_docs:
-            res = coll_data_objects.bulk_write(calc_docs, ordered=False)
+        if do_docs:
+            res = coll_data_objects.bulk_write(do_docs, ordered=False)
             nmatch = res.bulk_api_result["nMatched"]
             if nmatch:
                 warnings.warn("{} duplicate data objects detected".format(nmatch))

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -9,6 +9,7 @@ import numpy as np
 from tqdm import tqdm
 import multiprocessing
 from copy import deepcopy
+from deepdiff import DeepDiff
 from hashlib import sha512
 from functools import partial
 from pymongo import MongoClient, UpdateOne
@@ -608,9 +609,7 @@ class MongoDatabase(MongoClient):
         property_docs = []
         calc_docs = []
         meta_docs = []
-        #        co_relationships_dict = {}
-        #        pi_relationships_dict = {}
-        meta_update_dict = {}
+        meta_json = set()
         # Add all of the configurations into the Mongo server
         ai = 1
         for atoms in tqdm(
@@ -634,6 +633,7 @@ class MongoDatabase(MongoClient):
             ]
             if co_md_map:
                 co_md = Metadata.from_map(d=co_md_map, source=atoms)
+                print(co_md)
                 co_md_set_on_insert = _build_md_insert_doc(co_md)
                 co_md_update_doc = {  # update document
                     "$setOnInsert": co_md_set_on_insert,
@@ -1582,7 +1582,7 @@ class MongoDatabase(MongoClient):
             )
         )
         print(
-            f"Inserting configuration set",
+            "Inserting configuration set",
             f"({name}):".rjust(22),
             f"{len(filtered_cos)}".rjust(7),
         )
@@ -1666,7 +1666,8 @@ class MongoDatabase(MongoClient):
         )
 
     # TODO: need to make sure can't make duplicate CS just with different versions
-    # TODO: Could do this by creating ConfigurationSets for all versioned CS and use a defined equality with hashing
+    # TODO: Could do this by creating ConfigurationSets for all versioned CS and
+    # TODO: use a defined equality with hashing
     def update_configuration_set(self, cs_id, add_ids=None, remove_ids=None):
         if add_ids is None and remove_ids is None:
             raise RuntimeError(
@@ -1875,15 +1876,15 @@ class MongoDatabase(MongoClient):
             # 'methods_counts': [],
         }
 
-        ignore_keys = {
-            "property-id",
-            "property-title",
-            "property-description",
-            "_id",
-            SHORT_ID_STRING_NAME,
-            "property-name",
-            "hash",
-        }
+        # ignore_keys = {
+        #     "property-id",
+        #     "property-title",
+        #     "property-description",
+        #     "_id",
+        #     SHORT_ID_STRING_NAME,
+        #     "property-name",
+        #     "hash",
+        # }
 
         co_ids = []
 
@@ -2582,7 +2583,7 @@ class MongoDatabase(MongoClient):
         ds_doc = self.datasets.find_one({SHORT_ID_STRING_NAME: ds_id})
 
         configuration_sets = []
-        property_ids = []
+        # property_ids = []
 
         # Loop over configuration sets
         cursor = self.configuration_sets.find(

--- a/colabfit/tools/database.py
+++ b/colabfit/tools/database.py
@@ -2061,6 +2061,7 @@ class MongoDatabase(MongoClient):
         data_link=None,
         publication_link=None,
         other_links=None,
+        doi=None,
         resync=False,
         verbose=False,
         overloaded_ds_id=None,
@@ -2087,7 +2088,7 @@ class MongoDatabase(MongoClient):
             publication_link (str or None):
                 Source publication link (e.g., journal article DOI)
                 to be associated with the dataset.
-            
+
             data_link (str or None):
                 Source data link (e.g., repository DOI, GitHub link)
                 to be associated with the dataset.
@@ -2102,6 +2103,9 @@ class MongoDatabase(MongoClient):
 
             data_license (str):
                 License associated with the Dataset's data. SPDX identifier.
+
+            doi: (str):
+                DOI of the dataset. Default None.
 
             resync (bool):
                 If True, re-synchronizes the configuration sets and properties
@@ -2163,11 +2167,10 @@ class MongoDatabase(MongoClient):
             if isinstance(other_links, str):
                 other_links = [other_links]
         links = {
-            "source-publication":publication_link,
-            "source-data":data_link,
-            "other":other_links
-            }
-
+            "source-publication": publication_link,
+            "source-data": data_link,
+            "other": other_links,
+        }
 
         ds_hash = sha512()
         if cs_ids is not None:
@@ -2230,6 +2233,7 @@ class MongoDatabase(MongoClient):
                     "hash": str(ds_hash),
                     "license": data_license,
                     "publication-year": publication_year,
+                    "doi": doi,
                 },
                 "$set": {
                     "aggregated_info": aggregated_info,


### PR DESCRIPTION
The DO and CO aggregation functions have been refactored to use aggregation pipelines from MongoDB.

Test databases using existing scripts and a datasets have been added to the Kubernetes pod as: carolina_mat_agg_test and mtpu_agg_test. These should be directly comparable to the datasets as ingested to the current web database, plus or minus the order of elements in the dataset's aggregated information.

Carolina Materials is large enough to run into the problem where returning all the chemical formulae of a given type (hill, reduced, anonymous, chemical_system) causes a BSON size error. The aggregation functions therefore use batching, currently set to 10,000 configurations/batch.